### PR TITLE
改回使用2015版本进行生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Media Converter是一个可以转换媒体文件格式的UWP应用项目，应�
 
 通过应用商店的“试用”功能，可以免费下载本应用。若希望支持本项目，请在应用商店中购买。
 
-应用商店下载链接（最低版本：Windows 10 1511）：
+应用商店下载链接（最低版本：Windows 10 1607）：
 
 <a href="https://www.microsoft.com/store/apps/9ndjv6k3g2tj?ocid=github"><img src="https://assets.windowsphone.com/1cfd01f7-aad6-4896-8eb7-fea5f600e42d/Chinese_Simplified_Get_it_Win_10_InvariantCulture_Default.png" width="150" alt="在 Windows 10 上获取" /></a>
 
@@ -15,7 +15,7 @@ Media Converter是一个可以转换媒体文件格式的UWP应用项目，应�
 
 ## 生成
 在安装有以下软件的计算机上，可直接使用Visual Studio生成：
-- Visual Studio 2017以上版本
+- Visual Studio 2015以上版本
 - Windows 10 SDK 10.0.14393
 
 dev分支在AppVeyor上的生成状态：

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
   - master
   - dev
 skip_branch_with_pr: false
-image: Visual Studio 2017
+image: Visual Studio 2015
 environment:
   clientSecret:
     secure: u2MqrnmS+4jSw1IQjBViTCmrVJ5OUo8bvswGz3HcF4L+qX2ZPYNrPRSKfOpWMUvr


### PR DESCRIPTION
由于2017版本进行AppVeyor生成时存在找不到SDK的问题，先更换回2015进行生成。